### PR TITLE
Fix timer bug

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -72,7 +72,7 @@ const appStateReducer = (state, action) => {
       return {
         ...state,
         game_state: 'idle', 
-        startOfGame: new Date(), 
+        startGame: new Date(), 
         smileyState: 'c', 
         time: 0,
         mines: mines,


### PR DESCRIPTION
startGame was misspelled causing the timer to remain persistent when resetting games.